### PR TITLE
feat/chore: Fix Education Zones to use location codes

### DIFF
--- a/sctp-core/src/main/java/org/cga/sctp/schools/SchoolRepository.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/SchoolRepository.java
@@ -41,10 +41,13 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface SchoolRepository extends JpaRepository<School,Long> {
+public interface SchoolRepository extends JpaRepository<School, Long> {
 
     @Query(nativeQuery = true, value = "select * from schools_v")
     List<SchoolsView> getSchools();
+
+    @Query(nativeQuery = true, value =  "select * from schools_v")
+    Page<SchoolsView> getActiveSchoolsView(Pageable pageable);
 
     @Query
     Page<School> findAllByActive(boolean value, Pageable pageable);

--- a/sctp-core/src/main/java/org/cga/sctp/schools/SchoolService.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/SchoolService.java
@@ -55,7 +55,7 @@ public class SchoolService {
         return schoolRepository;
     }
 
-    public List<SchoolsView> getSchools(){
+    public List<SchoolsView> getSchools() {
         return schoolRepository.getSchools();
     }
 
@@ -74,8 +74,8 @@ public class SchoolService {
         return educationZoneRepository.findAll();
     }
 
-    public List<School> getActiveSchools() {
-        return schoolRepository.findAllByActive(true, Pageable.unpaged()).toList();
+    public Page<SchoolsView> getActiveSchools(Pageable pageable) {
+        return schoolRepository.getActiveSchoolsView(pageable);
     }
 
     public Page<School> getActiveSchoolsPaged(Pageable pageable) {

--- a/sctp-core/src/main/java/org/cga/sctp/schools/SchoolsView.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/SchoolsView.java
@@ -32,6 +32,10 @@
 
 package org.cga.sctp.schools;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
 public interface SchoolsView {
 
     Long getId();
@@ -47,4 +51,8 @@ public interface SchoolsView {
     String getEducationZone();
 
     String getDistrictName();
+
+    LocalDateTime getCreatedAt();
+
+    Boolean getActive();
 }

--- a/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZone.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZone.java
@@ -55,7 +55,6 @@ public class EducationZone {
     @Column(name = "name")
     private String name;
 
-    @NotEmpty
     @Column(name = "alt_name")
     private String altName;
 

--- a/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZone.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZone.java
@@ -35,7 +35,7 @@ package org.cga.sctp.schools.educationzone;
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 @Entity
 @Table(name = "education_zones")
@@ -45,35 +45,35 @@ public class EducationZone {
     private Long id;
 
     @NotNull
-    @Column(name="ta_id")
-    private Long taId;
+    @Column(name = "ta_code")
+    private Long taCode;
 
-    @Column(name="district_id")
-    private Long districtId;
+    @Column(name = "district_code")
+    private Long districtCode;
 
     @NotEmpty
-    @Column(name="name")
+    @Column(name = "name")
     private String name;
 
     @NotEmpty
-    @Column(name="alt_name")
+    @Column(name = "alt_name")
     private String altName;
 
     @NotEmpty
-    @Column(name="code")
+    @Column(name = "code")
     private String code;
 
     @NotNull
-    @Column(name="active")
+    @Column(name = "active")
     private boolean active;
 
     @NotNull
-    @Column(name="created_at")
-    private LocalDateTime createdAt;
+    @Column(name = "created_at")
+    private ZonedDateTime createdAt;
 
     @NotNull
-    @Column(name="updated_at")
-    private LocalDateTime updatedAt;
+    @Column(name = "updated_at")
+    private ZonedDateTime updatedAt;
 
     public Long getId() {
         return id;
@@ -83,20 +83,20 @@ public class EducationZone {
         this.id = id;
     }
 
-    public Long getTaId() {
-        return taId;
+    public Long getTaCode() {
+        return taCode;
     }
 
-    public void setTaId(Long taId) {
-        this.taId = taId;
+    public void setTaCode(Long taCode) {
+        this.taCode = taCode;
     }
 
-    public Long getDistrictId() {
-        return districtId;
+    public Long getDistrictCode() {
+        return districtCode;
     }
 
-    public void setDistrictId(Long districtId) {
-        this.districtId = districtId;
+    public void setDistrictCode(Long districtCode) {
+        this.districtCode = districtCode;
     }
 
     public String getName() {
@@ -131,19 +131,19 @@ public class EducationZone {
         this.active = active;
     }
 
-    public LocalDateTime getCreatedAt() {
+    public @NotNull ZonedDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
+    public void setCreatedAt(@NotNull ZonedDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public LocalDateTime getUpdatedAt() {
+    public @NotNull ZonedDateTime getUpdatedAt() {
         return updatedAt;
     }
 
-    public void setUpdatedAt(LocalDateTime updatedAt) {
+    public void setUpdatedAt(@NotNull ZonedDateTime updatedAt) {
         this.updatedAt = updatedAt;
     }
 }

--- a/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneRepository.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneRepository.java
@@ -32,12 +32,56 @@
 
 package org.cga.sctp.schools.educationzone;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface EducationZoneRepository extends JpaRepository<EducationZone, Long> {
+
+
+    @Query(nativeQuery = true, value = """
+                SELECT 
+                    eduzone.id AS id,
+                    ta.name AS taName ,
+                    district.name as districtName,
+                    eduzone.ta_code AS taCode,
+                    eduzone.district_code AS districtCode,
+                    eduzone.name,
+                    eduzone.alt_name AS altName,
+                    eduzone.code,
+                    eduzone.active,
+                    eduzone.created_at AS createdAt,
+                    eduzone.updated_at AS updatedAt
+                FROM education_zones eduzone
+                LEFT JOIN locations district ON district.code = eduzone.district_code
+                LEFT JOIN locations ta ON ta.code = eduzone.ta_code
+            """)
+    Page<EducationZoneView> fetchAllZonesPaged(Pageable pageable);
+
+    @Query(nativeQuery = true, value = """
+                SELECT 
+                    eduzone.id AS id,
+                    ta.name AS taName ,
+                    district.name as districtName,
+                    eduzone.ta_code AS taCode,
+                    eduzone.district_code AS districtCode,
+                    eduzone.name,
+                    eduzone.alt_name AS altName,
+                    eduzone.code,
+                    eduzone.active,
+                    eduzone.created_at AS createdAt,
+                    eduzone.updated_at AS updatedAt
+                FROM education_zones eduzone
+                LEFT JOIN locations district ON district.code = eduzone.district_code
+                LEFT JOIN locations ta ON ta.code = eduzone.ta_code
+                WHERE eduzone.id = :educationZoneId
+            """)
+    Optional<EducationZoneView> findByIdAsView(@Param("educationZoneId") Long educationZoneId);
 }

--- a/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneRepository.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneRepository.java
@@ -45,44 +45,9 @@ import java.util.Optional;
 @Repository
 public interface EducationZoneRepository extends JpaRepository<EducationZone, Long> {
 
-
-    @Query(nativeQuery = true, value = """
-                SELECT 
-                    eduzone.id AS id,
-                    ta.name AS taName ,
-                    district.name as districtName,
-                    eduzone.ta_code AS taCode,
-                    eduzone.district_code AS districtCode,
-                    eduzone.name,
-                    eduzone.alt_name AS altName,
-                    eduzone.code,
-                    eduzone.active,
-                    eduzone.created_at AS createdAt,
-                    eduzone.updated_at AS updatedAt
-                FROM education_zones eduzone
-                LEFT JOIN locations district ON district.code = eduzone.district_code
-                LEFT JOIN locations ta ON ta.code = eduzone.ta_code
-                WHERE eduzone.active = 1 
-            """)
+    @Query(nativeQuery = true, value = "SELECT * FROM education_zones_v")
     Page<EducationZoneView> fetchAllZonesPaged(Pageable pageable);
 
-    @Query(nativeQuery = true, value = """
-                SELECT 
-                    eduzone.id AS id,
-                    ta.name AS taName ,
-                    district.name as districtName,
-                    eduzone.ta_code AS taCode,
-                    eduzone.district_code AS districtCode,
-                    eduzone.name,
-                    eduzone.alt_name AS altName,
-                    eduzone.code,
-                    eduzone.active,
-                    eduzone.created_at AS createdAt,
-                    eduzone.updated_at AS updatedAt
-                FROM education_zones eduzone
-                LEFT JOIN locations district ON district.code = eduzone.district_code
-                LEFT JOIN locations ta ON ta.code = eduzone.ta_code
-                WHERE eduzone.id = :educationZoneId
-            """)
+    @Query(nativeQuery = true, value = "SELECT * FROM education_zones_v WHERE id = :educationZoneId")
     Optional<EducationZoneView> findByIdAsView(@Param("educationZoneId") Long educationZoneId);
 }

--- a/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneRepository.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneRepository.java
@@ -62,6 +62,7 @@ public interface EducationZoneRepository extends JpaRepository<EducationZone, Lo
                 FROM education_zones eduzone
                 LEFT JOIN locations district ON district.code = eduzone.district_code
                 LEFT JOIN locations ta ON ta.code = eduzone.ta_code
+                WHERE eduzone.active = 1 
             """)
     Page<EducationZoneView> fetchAllZonesPaged(Pageable pageable);
 

--- a/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneView.java
+++ b/sctp-core/src/main/java/org/cga/sctp/schools/educationzone/EducationZoneView.java
@@ -30,86 +30,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.cga.sctp.mis.schools.educationzone;
+package org.cga.sctp.schools.educationzone;
 
-import org.cga.sctp.mis.core.templating.Booleans;
+import java.time.LocalDateTime;
 
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
+public interface EducationZoneView {
+    Long getId();
 
-public class EducationZoneForm {
-    private Long id;
-    @NotNull
-    private Long taCode;
+    String getTaName();
 
-    @NotNull
-    private Long districtCode;
+    Long getTaCode();
 
-    @NotEmpty
-    private String name;
+    String getDistrictName();
 
-    @NotEmpty
-    private String altName;
+    Long getDistrictCode();
 
-    @NotEmpty
-    private String code;
+    String getName();
 
-    @NotNull
-    private Booleans active;
+    String getAltName();
 
-    public Long getId() {
-        return id;
-    }
+    String getCode();
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    boolean getActive();
 
-    public Long getTaCode() {
-        return taCode;
-    }
+    LocalDateTime getCreatedAt();
 
-    public void setTaCode(Long taCode) {
-        this.taCode = taCode;
-    }
-
-    public Long getDistrictCode() {
-        return districtCode;
-    }
-
-    public void setDistrictCode(Long districtCode) {
-        this.districtCode = districtCode;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getAltName() {
-        return altName;
-    }
-
-    public void setAltName(String altName) {
-        this.altName = altName;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    public Booleans isActive() {
-        return active;
-    }
-
-    public void setActive(Booleans active) {
-        this.active = active;
-    }
+    LocalDateTime getUpdatedAt();
 }

--- a/sctp-core/src/main/resources/db/migration/V1.84.1668687997363__Change_education_zone_locations_to_use_codes.sql
+++ b/sctp-core/src/main/resources/db/migration/V1.84.1668687997363__Change_education_zone_locations_to_use_codes.sql
@@ -1,0 +1,6 @@
+-- Alters the Education Zones table to use Location Codes instead of the IDs as foreign keys
+ALTER TABLE education_zones CHANGE ta_id ta_code BIGINT(19) NOT NULL COMMENT 'Traditional Authority where the Education Zone is';
+ALTER TABLE education_zones CHANGE district_id district_code BIGINT(19) NOT NULL COMMENT 'District where the Education Zone is';
+
+ALTER TABLE education_zones ADD CONSTRAINT fk_education_zone_ta FOREIGN KEY (ta_code) REFERENCES locations(code);
+ALTER TABLE education_zones ADD CONSTRAINT fk_education_zone_district FOREIGN KEY (district_code) REFERENCES locations(code);

--- a/sctp-core/src/main/resources/db/migration/V1.84.1669033911167__Modify_schools_v.sql
+++ b/sctp-core/src/main/resources/db/migration/V1.84.1669033911167__Modify_schools_v.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS schools_v;
+
+CREATE VIEW schools_v
+AS
+SELECT
+s.id ,
+s.name ,
+s.code ,
+s.active,
+s.modified_at AS modifiedAt,
+s.created_at AS createdAt,
+s.education_level as educationLevel,
+ez.name as educationZone,
+l.name as districtName,
+l.code AS districtCode
+FROM schools s
+LEFT JOIN education_zones ez ON s.education_zone = ez.id
+LEFT JOIN locations l ON l.code  = ez.district_code;

--- a/sctp-core/src/main/resources/db/migration/V1.84.1669035629682__Create_education_zones_v.sql
+++ b/sctp-core/src/main/resources/db/migration/V1.84.1669035629682__Create_education_zones_v.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS education_zones_v;
+
+CREATE VIEW education_zones_v
+AS
+SELECT
+  eduzone.id AS id,
+  ta.name AS taName ,
+  district.name as districtName,
+  eduzone.ta_code AS taCode,
+  eduzone.district_code AS districtCode,
+  eduzone.name,
+  eduzone.alt_name AS altName,
+  eduzone.code,
+  eduzone.active,
+  eduzone.created_at AS createdAt,
+  eduzone.updated_at AS updatedAt
+FROM education_zones eduzone
+LEFT JOIN locations district ON district.code = eduzone.district_code
+LEFT JOIN locations ta ON ta.code = eduzone.ta_code

--- a/sctp-mis/src/main/java/org/cga/sctp/mis/schools/SchoolsController.java
+++ b/sctp-mis/src/main/java/org/cga/sctp/mis/schools/SchoolsController.java
@@ -41,7 +41,9 @@ import org.cga.sctp.schools.SchoolService;
 import org.cga.sctp.schools.educationzone.EducationZone;
 import org.cga.sctp.targeting.importation.parameters.EducationLevel;
 import org.cga.sctp.user.AdminAccessOnly;
+import org.cga.sctp.user.AdminAndStandardAccessOnly;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
@@ -65,9 +67,11 @@ public class SchoolsController extends BaseController {
     private LocationService locationService;
 
     @GetMapping
-    ModelAndView index() {
+    @AdminAndStandardAccessOnly
+    public ModelAndView index(Pageable pageable) {
+        var schools = schoolsService.getActiveSchools(pageable);
         return view("schools/list")
-                .addObject("schools", schoolsService.getSchoolRepository().findAll());
+                .addObject("schools", schools);
     }
 
     @GetMapping("/new")

--- a/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneController.java
+++ b/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneController.java
@@ -203,18 +203,19 @@ public class EducationZoneController extends SecuredBaseController {
     public ModelAndView postDelete(@AuthenticatedUserDetails AuthenticatedUser user,
                                    @PathVariable("education-zone-id") Long id,
                                    RedirectAttributes attributes) {
-        Optional<EducationZoneView> educationZone = educationZoneRepository.findByIdAsView(id);
+        Optional<EducationZone> educationZone = educationZoneRepository.findById(id);
         if (educationZone.isEmpty()) {
             return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID does not exist", attributes);
         }
 
         try {
-            educationZoneRepository.deleteById(id);
-            publishGeneralEvent("User %s updated existing EducationZone id=%s name=%s", user.username(), id, educationZone.get().getName());
-            return view(redirectWithSuccessMessage("/schools/education-zones", "Education Zone with given ID deleted", attributes));
+            educationZone.get().setActive(false);
+            educationZoneRepository.save(educationZone.get());
+            publishGeneralEvent("User %s de-activated existing EducationZone id=%s name=%s", user.username(), id, educationZone.get().getName());
+            return view(redirectWithSuccessMessage("/schools/education-zones", "Education Zone with given ID de-activated", attributes));
         } catch (Exception e) {
-            LOG.error("Failed to deleted EducationZone", e);
-            return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID could not be deleted", attributes);
+            LOG.error("Failed to de-activate EducationZone", e);
+            return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID could not be de-activated", attributes);
         }
     }
 }

--- a/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneController.java
+++ b/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneController.java
@@ -38,19 +38,23 @@ import org.cga.sctp.mis.core.SecuredBaseController;
 import org.cga.sctp.mis.core.templating.Booleans;
 import org.cga.sctp.schools.educationzone.EducationZone;
 import org.cga.sctp.schools.educationzone.EducationZoneRepository;
+import org.cga.sctp.schools.educationzone.EducationZoneView;
 import org.cga.sctp.user.AdminAndStandardAccessOnly;
 import org.cga.sctp.user.AuthenticatedUser;
 import org.cga.sctp.user.AuthenticatedUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import java.time.ZonedDateTime;
 import java.util.Optional;
+
+import static org.cga.sctp.mis.location.LocationCodeUtil.toSelectOptions;
 
 @Controller
 @RequestMapping("/schools/education-zones")
@@ -64,8 +68,8 @@ public class EducationZoneController extends SecuredBaseController {
 
     @GetMapping
     @AdminAndStandardAccessOnly
-    public ModelAndView getIndex() {
-        List<EducationZone> educationZones = educationZoneRepository.findAll();
+    public ModelAndView getIndex(Pageable pageable) {
+        Page<EducationZoneView> educationZones = educationZoneRepository.fetchAllZonesPaged(pageable);
         return view("schools/education-zones/list")
                 .addObject("educationZones", educationZones);
     }
@@ -74,7 +78,7 @@ public class EducationZoneController extends SecuredBaseController {
     @AdminAndStandardAccessOnly
     public ModelAndView getCreate() {
         return view("schools/education-zones/new")
-                .addObject("districts", locationService.getActiveDistricts())
+                .addObject("districts", toSelectOptions(locationService.getActiveDistrictCodes()))
                 .addObject("traditionalAuthorities", locationService.getActiveByType(LocationType.SUBNATIONAL2))
                 .addObject("booleans", Booleans.VALUES);
     }
@@ -89,8 +93,8 @@ public class EducationZoneController extends SecuredBaseController {
         if (result.hasErrors()) {
             return withDangerMessage("schools/education-zones/new", "Please fix form errors")
                     .addObject(form)
-                    .addObject("districts", locationService.getActiveDistricts())
-                    .addObject("traditionalAuthorities", locationService.getActiveByType(LocationType.SUBNATIONAL2))
+                    .addObject("districts", toSelectOptions(locationService.getActiveDistrictCodes()))
+                    // T/As will be loaded dynamically .addObject("traditionalAuthorities", locationService.getActiveByType(LocationType.SUBNATIONAL2))
                     .addObject("booleans", Booleans.VALUES);
         }
 
@@ -98,13 +102,13 @@ public class EducationZoneController extends SecuredBaseController {
 
         newEducationZone.setAltName(form.getAltName());
         newEducationZone.setCode(form.getCode());
-        newEducationZone.setDistrictId(form.getDistrictId());
+        newEducationZone.setDistrictCode(form.getDistrictCode());
         newEducationZone.setId(form.getId());
         newEducationZone.setName(form.getName());
-        newEducationZone.setTaId(form.getTaId());
+        newEducationZone.setTaCode(form.getTaCode());
         newEducationZone.setActive(form.isActive().value);
-        newEducationZone.setCreatedAt(LocalDateTime.now());
-        newEducationZone.setUpdatedAt(LocalDateTime.now());
+        newEducationZone.setCreatedAt(ZonedDateTime.now());
+        newEducationZone.setUpdatedAt(ZonedDateTime.now());
 
         educationZoneRepository.save(newEducationZone);
 
@@ -113,48 +117,32 @@ public class EducationZoneController extends SecuredBaseController {
         return redirect("/schools/education-zones");
     }
 
-    @GetMapping("/{education-zone-id}/view")
-    @AdminAndStandardAccessOnly
-    public ModelAndView getView(@PathVariable("education-zone-id") Long id, RedirectAttributes attributes) {
-
-        Optional<EducationZone> educationZone = educationZoneRepository.findById(id);
-
-        if (educationZone.isEmpty()) {
-            return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID does not exist", attributes);
-        }
-
-        return view("schools/education-zones/view")
-                // TODO: .addObject("district", ...)
-                // TODO: .addObject("ta", ...)
-                .addObject("educationZone", educationZone.get());
-    }
-
     @GetMapping("/{education-zone-id}/edit")
     @AdminAndStandardAccessOnly
     public ModelAndView getEdit(@PathVariable("education-zone-id") Long id,
                                 @ModelAttribute("form") EducationZoneForm form,
                                 RedirectAttributes attributes) {
-        Optional<EducationZone> educationZoneOptional = educationZoneRepository.findById(id);
+        Optional<EducationZoneView> educationZoneOptional = educationZoneRepository.findByIdAsView(id);
 
         if (educationZoneOptional.isEmpty()) {
             return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID does not exist", attributes);
         }
 
-        EducationZone educationZone = educationZoneOptional.get();
+        EducationZoneView educationZone = educationZoneOptional.get();
         form.setCode(educationZone.getCode());
-        form.setDistrictId(educationZone.getDistrictId());
+        form.setDistrictCode(educationZone.getDistrictCode());
         form.setId(educationZone.getId());
-        form.setTaId(educationZone.getTaId());
+        form.setTaCode(educationZone.getTaCode());
         form.setName(educationZone.getName());
         form.setAltName(educationZone.getAltName());
-        form.setActive(Booleans.of(educationZone.isActive()));
+        form.setActive(Booleans.of(educationZone.getActive()));
 
 
         return view("schools/education-zones/edit")
                 .addObject(form)
                 .addObject("educationZone", educationZone)
-                .addObject("districts", locationService.getActiveDistricts())
-                .addObject("traditionalAuthorities", locationService.getActiveByType(LocationType.SUBNATIONAL2))
+                .addObject("districts", toSelectOptions(locationService.getActiveDistrictCodes()))
+                .addObject("taCodes", toSelectOptions(locationService.getLocationCodesByParent(educationZone.getDistrictCode())))
                 .addObject("booleans", Booleans.VALUES);
     }
 
@@ -175,22 +163,21 @@ public class EducationZoneController extends SecuredBaseController {
             return withDangerMessage("schools/education-zones/edit", "Please fix form errors")
                     .addObject(form)
                     .addObject("educationZone", entity)
-                    .addObject("districts", locationService.getActiveDistricts())
+                    .addObject("districts", toSelectOptions(locationService.getActiveDistrictCodes()))
                     .addObject("traditionalAuthorities", locationService.getActiveByType(LocationType.SUBNATIONAL2))
                     .addObject("booleans", Booleans.VALUES);
         }
 
 
-
         entity.setAltName(form.getAltName());
         entity.setCode(form.getCode());
-        entity.setDistrictId(form.getDistrictId());
+        entity.setDistrictCode(form.getDistrictCode());
         entity.setId(form.getId());
         entity.setName(form.getName());
-        entity.setTaId(form.getTaId());
+        entity.setTaCode(form.getTaCode());
         entity.setActive(form.isActive().value);
-        entity.setCreatedAt(LocalDateTime.now());
-        entity.setUpdatedAt(LocalDateTime.now());
+        entity.setCreatedAt(ZonedDateTime.now());
+        entity.setUpdatedAt(ZonedDateTime.now());
 
         educationZoneRepository.save(entity);
 
@@ -199,4 +186,35 @@ public class EducationZoneController extends SecuredBaseController {
         return redirect("/schools/education-zones");
     }
 
+    @GetMapping("/{education-zone-id}/delete")
+    @AdminAndStandardAccessOnly
+    public ModelAndView getDelete(@PathVariable("education-zone-id") Long id, RedirectAttributes attributes) {
+
+        Optional<EducationZoneView> educationZone = educationZoneRepository.findByIdAsView(id);
+        if (educationZone.isEmpty()) {
+            return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID does not exist", attributes);
+        }
+        return view("schools/education-zones/delete")
+                .addObject("educationZone", educationZone.get());
+    }
+
+    @PostMapping("/{education-zone-id}/delete")
+    @AdminAndStandardAccessOnly
+    public ModelAndView postDelete(@AuthenticatedUserDetails AuthenticatedUser user,
+                                   @PathVariable("education-zone-id") Long id,
+                                   RedirectAttributes attributes) {
+        Optional<EducationZoneView> educationZone = educationZoneRepository.findByIdAsView(id);
+        if (educationZone.isEmpty()) {
+            return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID does not exist", attributes);
+        }
+
+        try {
+            educationZoneRepository.deleteById(id);
+            publishGeneralEvent("User %s updated existing EducationZone id=%s name=%s", user.username(), id, educationZone.get().getName());
+            return view(redirectWithSuccessMessage("/schools/education-zones", "Education Zone with given ID deleted", attributes));
+        } catch (Exception e) {
+            LOG.error("Failed to deleted EducationZone", e);
+            return redirectWithDangerMessageModelAndView("/schools/education-zones", "Education Zone with given ID could not be deleted", attributes);
+        }
+    }
 }

--- a/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneController.java
+++ b/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneController.java
@@ -47,6 +47,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -76,7 +77,7 @@ public class EducationZoneController extends SecuredBaseController {
 
     @GetMapping("/new")
     @AdminAndStandardAccessOnly
-    public ModelAndView getCreate() {
+    public ModelAndView getCreate(@ModelAttribute("form") EducationZoneForm form) {
         return view("schools/education-zones/new")
                 .addObject("districts", toSelectOptions(locationService.getActiveDistrictCodes()))
                 .addObject("traditionalAuthorities", locationService.getActiveByType(LocationType.SUBNATIONAL2))
@@ -86,7 +87,7 @@ public class EducationZoneController extends SecuredBaseController {
     @PostMapping("/new")
     @AdminAndStandardAccessOnly
     public ModelAndView postCreate(@AuthenticatedUserDetails AuthenticatedUser user,
-                                   @ModelAttribute EducationZoneForm form,
+                                   @Validated @ModelAttribute("form") EducationZoneForm form,
                                    BindingResult result,
                                    RedirectAttributes attributes) {
 

--- a/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneForm.java
+++ b/sctp-mis/src/main/java/org/cga/sctp/mis/schools/educationzone/EducationZoneForm.java
@@ -48,7 +48,6 @@ public class EducationZoneForm {
     @NotEmpty
     private String name;
 
-    @NotEmpty
     private String altName;
 
     @NotEmpty

--- a/sctp-mis/src/main/resources/public/assets/js/education_zones_locations.js
+++ b/sctp-mis/src/main/resources/public/assets/js/education_zones_locations.js
@@ -1,0 +1,45 @@
+// TODO: refactor this script to be useable everywhere we have the location options for district + t/a.
+(function(){
+    // Functionality for Card Toggling only for this page..
+    let cardToggles = document.getElementsByClassName('card-toggle');
+    for (let i = 0; i < cardToggles.length; i++) {
+        cardToggles[i].addEventListener('click', e => {
+            e.currentTarget.parentElement.parentElement.childNodes[3].classList.toggle('is-hidden');
+        });
+    }
+
+    let disabledOpt = new Option('Select Option', -1);
+    disabledOpt.disable = true;
+    window.renderOptions = function(list, promise, prepend, useExtraField){
+        list.length = 0;
+        if(prepend){
+            list.options.add(disabledOpt);
+        }
+        promise.json().then(items => items.forEach(item => list
+            .options.add(new Option(item.text, useExtraField ? item.extra : item.id))));
+    };
+    window.getOptions = function(url, onSuccess, onError){
+        var params = { method: 'GET' };
+        try {
+            fetch(url, params)
+            .then(r => onSuccess(r))
+            .catch(e => onError(e));
+        }catch(e){
+            onError(e);
+        }
+    };
+    window.loadLocations = function(target, sender, prepend, useExtraField){
+        getOptions(
+            '/locations/get-child-locations?id=' + sender.selectedOptions[0].value,
+            function(data){
+                renderOptions(target, data, prepend, useExtraField);
+            },
+            function(error){
+                console.log(error);
+                alert('There was an error getting locations from the server.');
+            }
+         );
+    };
+    districtCode.onchange = function(){ taCode.length = 0; loadLocations(taCode, this, true, true); };
+    taCode.onchange = function(){ loadLocations(clusterCode, this, false, true); };
+})();

--- a/sctp-mis/src/main/resources/templates/schools/edit.peb
+++ b/sctp-mis/src/main/resources/templates/schools/edit.peb
@@ -97,19 +97,6 @@
                     </div>
                 </div>
                 <div class="columns">
-                    <div class="column">
-                        <div class="field">
-                            <label class="label is-required">District</label>
-                            <div class="control">
-                                <div class="select is-fullwidth">
-                                        {{ selectField('districtId', districts, schoolForm.districtId, true) }}
-                                </div>
-                            </div>
-                            {{ printFieldErrors(getFieldErrors('schoolForm', 'districtId')) }}
-                        </div>
-                    </div>
-                </div>
-                <div class="columns">
                     <div class="column is-one-fifth">
                         <div class="field">
                             <label class="label is-required">Active</label>

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/delete.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/delete.peb
@@ -1,0 +1,38 @@
+
+    {% extends "../../base" %}
+        {% import "../../../utils/form" %}
+        {% block contextMenu %}
+        <div class="container context-nav-container">
+            <div class="buttons is-right">
+                <a href="{{ href('/schools/education-zones') }}" class="button is-warning">Back</a>
+            </div>
+        </div>
+        {% endblock %}
+
+    {% block content %}
+
+    <div class="container">
+        <div class="card no-overlap">
+            <header class="card-header">
+                <p class="card-header-title">Are you sure you want delete the following Education Zone?</p>
+            </header>
+            <div class="card-content">
+                <div class="action-buttons well">
+                    <form method="post" action="/schools/education-zones/{{ educationZone.id }}/delete">
+                        {{ csrf(_csrf) }}
+                        <input type="hidden" name="periodId" value="{{ educationZone.id }}">
+                        <button name="confirmDelete" class="button is-danger">Yes, delete Education Zone</button>
+                        <a href="/schools/education-zones" class="button is-warning">No, Cancel</a>
+                    </form>
+                </div>
+
+                <div class="display-content">
+                    <div class="field-display">
+                        <label class="label">Name</label>
+                        <h3 class="subtitle">{{ educationZone.name }}</h3>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endblock %}

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/edit.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/edit.peb
@@ -42,7 +42,7 @@
                     <div class="field">
                         <label for="name" class="label">Alt. Name</label>
                         <div class="control">
-                                {{ textField('altName', form.altName, 1, 200, true, null) }}
+                                {{ textField('altName', form.altName, 1, 200, false, null) }}
                         </div>
                         {{ printFieldErrors(getFieldErrors('form', 'altName')) }}
                     </div>

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/edit.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/edit.peb
@@ -27,12 +27,13 @@
                   method="post"
                   enctype="application/x-www-form-urlencoded" >
                 <div class="card-content">
+                    <input type="hidden" name="id" value="{{ educationZone.id }}" />
 
                     {{ showMessages(successMessage, infoMessage, dangerMessage, warningMessage) }}
-                    <input type="hidden" name="id" value="{{ educationZone.id }}" />
+
                     {{ csrf(_csrf) }}
                     <div class="field">
-                        <label for="name" class="label">Name</label>
+                        <label for="name" class="label is-required">Name</label>
                         <div class="control">
                                 {{ textField('name', form.name, 1, 200, true, null) }}
                         </div>
@@ -46,32 +47,32 @@
                         {{ printFieldErrors(getFieldErrors('form', 'altName')) }}
                     </div>
                     <div class="field">
-                        <label for="name" class="label">Code</label>
+                        <label for="name" class="label is-required">Code</label>
                         <div class="control">
                                 {{ textField('code', form.code, 1, 100, true, null) }}
                         </div>
                         {{ printFieldErrors(getFieldErrors('form', 'code')) }}
                     </div>
                     <div class="field">
-                        <label for="name" class="label">District</label>
+                        <label for="name" class="label is-required">District</label>
                         <div class="control">
                             <div class="select is-fullwidth">
-                                    {{ selectField('districtId', districts, form.districtId, true) }}
+                                    {{ selectField('districtCode', districts, form.districtCode, true) }}
                             </div>
                         </div>
-                        {{ printFieldErrors(getFieldErrors('form', 'districtId')) }}
+                        {{ printFieldErrors(getFieldErrors('form', 'districtCode')) }}
                     </div>
                     <div class="field">
-                        <label for="name" class="label">Traditional Authority</label>
+                        <label class="label is-required">T / A</label>
                         <div class="control">
                             <div class="select is-fullwidth">
-                                    {{ selectField('taId', traditionalAuthorities, form.taId, true) }}
+                                {{ selectField('taCode', taCodes, form.taCode, true) }}
                             </div>
+                            {{ printFieldErrors(getFieldErrors('form', 'taCode')) }}
                         </div>
-                        {{ printFieldErrors(getFieldErrors('form', 'taId')) }}
                     </div>
                     <div class="field">
-                        <label for="name" class="label">Active</label>
+                        <label for="name" class="label is-required">Active</label>
                         <div class="control">
                             <div class="select is-fullwidth">
                                     {{ selectField('active', booleans, form.active, true) }}
@@ -89,3 +90,6 @@
         </div>
     </div>
     {% endblock%}
+    {% block footerScripts %}
+    <script type="text/javascript" src="/assets/js/education_zones_locations.js"></script>
+    {% endblock %}

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/list.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/list.peb
@@ -37,8 +37,8 @@
                             <tr>
                                 <td>{{ e.name }}</td>
                                 <td>{{ e.code }}</td>
-                                <td>{{ e.districtId }}</td>
-                                <td>{{ e.taid }}</td>
+                                <td>{{ e.districtName }}</td>
+                                <td>{{ e.taName }}</td>
                                 <td>{{ printDate(e.createdAt) }}</td>
                                 <td>{{ yesOrNo(e.active) }}</td>
                                 <td>
@@ -56,6 +56,7 @@
                                             <div class="dropdown-menu" id="dropdown-menu2" role="menu">
                                                 <div class="dropdown-content">
                                                     <a href="/schools/education-zones/{{ e.id }}/edit" class="dropdown-item">Edit Education Zone</a>
+                                                    <a href="/schools/education-zones/{{ e.id }}/delete" class="dropdown-item is-warning">Delete Education Zone</a>
                                                 </div>
                                             </div>
                                         </div>

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/new.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/new.peb
@@ -41,7 +41,7 @@
                 <div class="field">
                     <label for="name" class="label">Alt. Name</label>
                     <div class="control">
-                            {{ textField('altName', form.altName, 1, 200, true, null) }}
+                            {{ textField('altName', form.altName, 1, 200, false, null) }}
                     </div>
                     {{ printFieldErrors(getFieldErrors('form', 'altName')) }}
                 </div>

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/new.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/new.peb
@@ -32,7 +32,7 @@
 
                 {{ csrf(_csrf) }}
                 <div class="field">
-                    <label for="name" class="label">Name</label>
+                    <label for="name" class="label is-required">Name</label>
                     <div class="control">
                             {{ textField('name', form.name, 1, 200, true, null) }}
                     </div>
@@ -46,32 +46,34 @@
                     {{ printFieldErrors(getFieldErrors('form', 'altName')) }}
                 </div>
                 <div class="field">
-                    <label for="name" class="label">Code</label>
+                    <label for="name" class="label is-required">Code</label>
                     <div class="control">
                             {{ textField('code', form.code, 1, 100, true, null) }}
                     </div>
                     {{ printFieldErrors(getFieldErrors('form', 'code')) }}
                 </div>
                 <div class="field">
-                    <label for="name" class="label">District</label>
+                    <label for="name" class="label is-required">District</label>
                     <div class="control">
                         <div class="select is-fullwidth">
-                                {{ selectField('districtId', districts, form.districtId, true) }}
+                                {{ selectField('districtCode', districts, form.districtCode, true) }}
                         </div>
                     </div>
-                    {{ printFieldErrors(getFieldErrors('form', 'districtId')) }}
+                    {{ printFieldErrors(getFieldErrors('form', 'districtCode')) }}
                 </div>
                 <div class="field">
-                    <label for="name" class="label">Traditional Authority</label>
+                    <label class="label is-required">T / A</label>
                     <div class="control">
                         <div class="select is-fullwidth">
-                                {{ selectField('taId', traditionalAuthorities, form.taId, true) }}
+                            <select class="select control" name="taCode" id="taCode">
+                                {#  to be loaded via JavaScript here #}
+                            </select>
                         </div>
+                        {{ printFieldErrors(getFieldErrors('form', 'taCode')) }}
                     </div>
-                    {{ printFieldErrors(getFieldErrors('form', 'taId')) }}
                 </div>
                 <div class="field">
-                    <label for="name" class="label">Active</label>
+                    <label for="name" class="label is-required">Active</label>
                     <div class="control">
                         <div class="select is-fullwidth">
                                 {{ selectField('active', booleans, form.active, true) }}
@@ -89,3 +91,6 @@
     </div>
 </div>
 {% endblock%}
+{% block footerScripts %}
+<script type="text/javascript" src="/assets/js/education_zones_locations.js"></script>
+{% endblock %}

--- a/sctp-mis/src/main/resources/templates/schools/education-zones/view.peb
+++ b/sctp-mis/src/main/resources/templates/schools/education-zones/view.peb
@@ -1,1 +1,0 @@
-{% extends "schools/base" %}

--- a/sctp-mis/src/main/resources/templates/schools/new.peb
+++ b/sctp-mis/src/main/resources/templates/schools/new.peb
@@ -97,19 +97,6 @@
                     </div>
                 </div>
                 <div class="columns">
-                    <div class="column">
-                        <div class="field">
-                            <label class="label is-required">District</label>
-                            <div class="control">
-                                <div class="select is-fullwidth">
-                                        {{ selectField('districtId', districts, schoolForm.districtId, true) }}
-                                </div>
-                            </div>
-                            {{ printFieldErrors(getFieldErrors('schoolForm', 'districtId')) }}
-                        </div>
-                    </div>
-                </div>
-                <div class="columns">
                     <div class="column is-one-fifth">
                         <div class="field">
                             <label class="label is-required">Active</label>


### PR DESCRIPTION
Fixed the education zone entity to use taCode and districtCode and fixed some of the functionality of the feature including

- adding migration for the location codes
- Adding a delete page
- adding a view entity to fetch districtName and taName
- Adding javascript to toggle the location selection input controls
- Consolidating the edit and new templates
- updating the educationform class